### PR TITLE
remove consulting link for now

### DIFF
--- a/source/views/wrapper.js
+++ b/source/views/wrapper.js
@@ -70,7 +70,6 @@ function renderNavigation (state, emit) {
         </h3>
 
         <div class="flex-grow pa3 pa0-l flex-none-l items-center">
-          <a class="link black-70 f5 f4-ns fw6 dim mr3 mr4-ns" href="/collaborative-communities" title="Collaborative Communities">Consulting</a>
           <a class="link black-70 f5 f4-ns fw6 dim" target="_blank" href="https://blog.codeforscience.org/" title="CSS Blog">Blog</a>
         </div>
       </div>


### PR DESCRIPTION
* After discussion at board meeting, consulting work should be more focused on existing relationships and tangential to project work. Business development + Marketing may be too time-consuming for now.